### PR TITLE
Update _misc.scss

### DIFF
--- a/gtk-3.20/scss/widgets/_misc.scss
+++ b/gtk-3.20/scss/widgets/_misc.scss
@@ -21,7 +21,6 @@
 
             border: 0;
             border-radius: $roundness;
-            color: $tooltip_fg_color;
         }
 
         * {

--- a/gtk-3.20/scss/widgets/_misc.scss
+++ b/gtk-3.20/scss/widgets/_misc.scss
@@ -15,7 +15,7 @@
 ************/
 
 @include exports("tooltip") {
-    .tooltip {
+    tooltip {
         &.background {
             @include linear-gradient($tooltip_bg_color);
 


### PR DESCRIPTION
Fixes issue Antergos/Numix-Frost#38 (Firefox - Tooltips invisible)
This fix is only a workaround, because I was not able to set the same tooltip background and foreground colour for all applications.
When I tested the fix for firefox, nemo and gedit, I notice that changes to the background colour property only takes effect for firefox. And changes to the foreground colour property only takes effect for nemo and gedit.

The workaround is to only set the background colour to dark grey. (And unset the foreground colour.) Now the tooltips are readable in all three applications, but with different colours.

Maybe someone else have an idea.